### PR TITLE
refactor: updating package structure for EmailApiClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Testcontainers has been used to test the below modules in the application:
 
 #### Outbound API Communication (Egress HTTP call)
 
-- **Integration Test:** [NotificationServiceIT.java](https://github.com/hardikSinghBehl/just-another-testcontainer-integration/blob/main/src/test/java/com/behl/receptacle/service/NotificationServiceIT.java)
+- **Integration Test:** [EmailApiClientIT.java](https://github.com/hardikSinghBehl/just-another-testcontainer-integration/blob/main/src/test/java/com/behl/receptacle/client/EmailApiClientIT.java)
 - **Description:** This test validates the egress/external HTTP call made by the application to send email notifications. The test utilizes [MockServer](https://www.mock-server.com/) to mock the server's response and verify the interaction with the server. The test covers scenarios such as successful email notification dispatch and failure scenarios with appropriate error handling.
 
 ---

--- a/src/main/java/com/behl/receptacle/client/EmailApiClient.java
+++ b/src/main/java/com/behl/receptacle/client/EmailApiClient.java
@@ -1,4 +1,4 @@
-package com.behl.receptacle.service;
+package com.behl.receptacle.client;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpEntity;
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @EnableConfigurationProperties(EmailClientConfigurationProperties.class)
-public class NotificationService {
+public class EmailApiClient {
   
     private final RestTemplate restTemplate;
     private final EmailClientConfigurationProperties emailClientConfigurationProperties;

--- a/src/test/java/com/behl/receptacle/client/EmailApiClientIT.java
+++ b/src/test/java/com/behl/receptacle/client/EmailApiClientIT.java
@@ -1,4 +1,4 @@
-package com.behl.receptacle.service;
+package com.behl.receptacle.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockserver.model.HttpRequest.request;
@@ -23,10 +23,10 @@ import net.bytebuddy.utility.RandomString;
 @SpringBootTest
 @ActiveProfiles("test")
 @EnableAutoConfiguration(exclude = FlywayAutoConfiguration.class)
-public class NotificationServiceIT {
+public class EmailApiClientIT {
   
     @Autowired
-    private NotificationService notificationService;  
+    private EmailApiClient emailApiClient;  
   
     private static MockServerClient mockServerClient;
     private static final String EMAIL_SERVER_API_KEY  = RandomString.make(20);
@@ -56,20 +56,20 @@ public class NotificationServiceIT {
         // Set up mock server to expect the egress HTTP request
         mockServerClient
             .when(request()
-                .withPath(NotificationService.SEND_EMAIL_API_PATH)
+                .withPath(EmailApiClient.SEND_EMAIL_API_PATH)
                 .withHeader("Authorization", "Bearer " + EMAIL_SERVER_API_KEY)
                 .withBody(emailDispatchJsonRequest).withMethod(HttpMethod.POST.name()))
             .respond(response()
                 .withStatusCode(200));
         
         // Send email notification
-        final var response = notificationService.sendEmail(emailDispatchRequest);
+        final var response = emailApiClient.sendEmail(emailDispatchRequest);
         
         // Verify response and mock server interaction
         assertThat(response).isTrue();
         mockServerClient.verify(
             request()
-                .withPath(NotificationService.SEND_EMAIL_API_PATH)
+                .withPath(EmailApiClient.SEND_EMAIL_API_PATH)
                 .withHeader("Authorization", "Bearer " + EMAIL_SERVER_API_KEY)
                 .withBody(emailDispatchJsonRequest).withMethod(HttpMethod.POST.name()),
             VerificationTimes.once()
@@ -88,20 +88,20 @@ public class NotificationServiceIT {
         // Set up mock server to expect the egress HTTP request and return HttpStatus.503
         mockServerClient
             .when(request()
-                .withPath(NotificationService.SEND_EMAIL_API_PATH)
+                .withPath(EmailApiClient.SEND_EMAIL_API_PATH)
                 .withHeader("Authorization", "Bearer " + EMAIL_SERVER_API_KEY)
                 .withBody(emailDispatchJsonRequest).withMethod(HttpMethod.POST.name()))
             .respond(response()
                 .withStatusCode(503));
         
         // Send email notification
-        final var response = notificationService.sendEmail(emailDispatchRequest);
+        final var response = emailApiClient.sendEmail(emailDispatchRequest);
         
         // Verify response and mock server interaction
         assertThat(response).isFalse();
         mockServerClient.verify(
             request()
-                .withPath(NotificationService.SEND_EMAIL_API_PATH)
+                .withPath(EmailApiClient.SEND_EMAIL_API_PATH)
                 .withHeader("Authorization", "Bearer " + EMAIL_SERVER_API_KEY)
                 .withBody(emailDispatchJsonRequest).withMethod(HttpMethod.POST.name()),
             VerificationTimes.once()


### PR DESCRIPTION
`NotificationService.java` to be renamed to `EmailApiClient.java` and moved to client package from service package to follow coding standards